### PR TITLE
Styling change on sign-up section

### DIFF
--- a/css/home/sign-up.css
+++ b/css/home/sign-up.css
@@ -54,7 +54,6 @@ h2 {
 p {
   text-align: center;
   line-height: 30px;
-  padding-bottom: 20px;
 }
 
 button {


### PR DESCRIPTION
Tweaked the spacing in this sign-up section to match the design brief for desktop. 

<img width="1499" alt="image" src="https://github.com/technative-academy/Dream-Generator/assets/156936136/b15fe205-7a95-4417-b3ad-b425ace10bc7">
