### PR TITLE
Add styling to the contact form

### DIFF
--- a/about.html
+++ b/about.html
@@ -40,7 +40,7 @@
 	</div>
 	<div class="hero-container about-us-container">
 		<h1>About us</h1>
-		<p>Dream big, dream bold, dream with us at Dreamland</p>
+		<p>Dream big, dream bold, dream with us at Dreamland.</p>
 	</div>
 	<main>
 		<section>
@@ -55,6 +55,7 @@
 						creating breathtaking events, designing awe-inspiring spaces, or crafting bespoke solutions
 						tailored to individual needs, Dreamland is dedicated to exceeding expectations and surpassing
 						boundaries.</p>
+						<br> 
 					<p>Driven by creativity, fueled by imagination, and guided by integrity, Dreamland stands as a
 						beacon of hope and inspiration in a world yearning for magic and wonder. With a team of
 						visionary professionals who share a collective dedication to excellence, we embark on each
@@ -75,12 +76,12 @@
 						referrerpolicy="no-referrer-when-downgrade"></iframe>
 					<div class="adress">
 						<strong>
-							<p>Our adress</p>
+							<p>Our address</p>
 						</strong>
 						<ul>
 							<li>48 Fake street</li>
-							<li>Fakes ville</li>
-							<li>FK 1FK</li>
+							<li>Fakesville</li>
+							<li>FK1 1FK</li>
 						</ul>
 					</div>
 				</div>
@@ -88,16 +89,15 @@
 
 					<form action="form">
 						<h2 class="contact-head">Contact us</h2>
-						<p>Email us on <a href="#">hello@blah.com</a> or enter ypur message here</p>
-						<label for="name">Name:</label><br>
-
-						<input type="text" name="name" id="name" placeholder="Place you name" minlength="8"
+						<p>Email us on <a href="#">hello@blah.com</a> or enter your message below</p>
+						<label for="name">Name:</label>
+						<input class ="input" type="text" name="name" id="name" placeholder="Your name" minlength="8"
 							maxlength="15" required />
 						<label for="email">Email:</label>
-						<input type="email" name="email" id="email" placeholder="Your email" minlength="8"
+						<input class ="input" type="email" name="email" id="email" placeholder="name@yourcompany.com" minlength="8"
 							maxlength="15" required />
 						<label for="message">Message:</label>
-						<textarea id="message" name="message" rows="10" cols="33" input
+						<textarea class ="input" id="message" name="message" rows="10" cols="33" input
 							placeholder="Enter your message here"></textarea>
 						<button type="submit" class="btn">Submit</button>
 					</form>

--- a/css/about/contact-form.css
+++ b/css/about/contact-form.css
@@ -27,6 +27,19 @@ form {
   margin-top: 50px;
 }
 
+.input {
+  border: solid 2px #e1e1e4;
+  width: 100%;
+  padding: 12px 20px;
+  -webkit-transition: 0.5s;
+  transition: 0.5s;
+  outline: none;
+}
+
+.input:focus {
+  border: solid 2px rgb(78, 90, 101);
+}
+
 @media only screen and (min-width: 1000px) {
   .contact {
     flex-direction: row;


### PR DESCRIPTION
I've added styling to the contact form to match the brief for mobile/desktop and to keep the spacing consistent. When you click on the input fields to enter text they now transition into a darker border -- I did this using a transition and :focus. 

<img width="500" alt="image" src="https://github.com/technative-academy/Dream-Generator/assets/156936136/74ec1867-bd5b-40f4-9611-66bf5fa62364">
