### PR TITLE
Add gap on mobile facts and view more button

### DIFF
--- a/css/home/facts.css
+++ b/css/home/facts.css
@@ -3,6 +3,7 @@
   flex-direction: column;
   align-items: center;
   margin: 20px 100px;
+  row-gap: 60px;
 }
 
 .facts-container h3 {
@@ -13,6 +14,12 @@
   text-align: center;
   display: block;
   padding: 10px;
+}
+
+.view-more-btn {
+  background: var(--cta-bg);
+  margin-left: 100px;
+  height: 50px;
 }
 
 @media only screen and (max-width: 700px) {
@@ -44,6 +51,10 @@
   .fact-container {
     margin-left: 150px;
     margin-right: 150px;
+  }
+
+  .view-more-btn {
+    display: none;
   }
 }
 


### PR DESCRIPTION
Have added a gap between the facts on the the desktop and mobile version. Have also included a 'view more' button at the bottom of the facts on the mobile version.

<img width="494" alt="image" src="https://github.com/technative-academy/Dream-Generator/assets/156936136/15a58fbd-1af5-4e75-a613-990b99062b41">

<img width="472" alt="image" src="https://github.com/technative-academy/Dream-Generator/assets/156936136/a752dbfa-7889-4c22-9838-7f3c8f451311">
